### PR TITLE
Add HTTPS VHost to xdmod.conf with updated variables in group_vars/all

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -37,6 +37,10 @@
   xdmod_shredder_end_time: "date +'\\%FT\\%T'"
   xdmod_ingestor_start_date: "date +'\\%F'"
   xdmod_ingestor_end_date: "date -d 'next day' +'\\%F'"
+  
+  ServerName: ""
+  SSLCertificateFile: ""
+  SSLCertificateKeyFile: ""
 
 # SUPReMM
 

--- a/roles/openxdmod/templates/xdmod.conf
+++ b/roles/openxdmod/templates/xdmod.conf
@@ -1,70 +1,51 @@
-# We recommend that you use HTTPS in production.  If your web server is
-# not already listening on port 443 you will need to uncomment the
-# following "Listen" directive or add it to the appropriate section in
-# your Apache configuration:
-#
-#Listen 443
-#
-# Likewise, you will need to change the port number in the "VirtualHost"
-# directive below to 443:
-#
-#<VirtualHost *:443>
-#
-# In addition to those two steps you will also need to uncomment and
-# modify the section below that starts with "SSLEngine on".
-#
-# For more details about enabling SSL refer to the Apache documentation
-# located at http://httpd.apache.org/docs/2.4/ssl/
+<IfModule !mod_ssl.c>
+    LoadModule ssl_module modules/mod_ssl.so
+</IfModule>
 
-#Alias /xdmod /usr/share/xdmod/html
+Listen 443
 
 <VirtualHost *:80>
-    #ServerName {{ headnode_public_ip }}
-    ServerName {{ xdmod_public_name }}
-    #ServerAdmin admin@open-xdmod.localdomain
-
-    ## Customize this section using your SSL certificate.
-    #SSLEngine on
-    #SSLCertificateFile    /etc/ssl/certs/ssl-cert-snakeoil.pem
-    #SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key
-    #<FilesMatch "\.(cgi|shtml|phtml|php)$">
-    #    SSLOptions +StdEnvVars
-    #</FilesMatch>
-
-    DocumentRoot /usr/share/xdmod/html
-
-    <Directory /usr/share/xdmod/html>
-#<Location /xdmod>
-        Options FollowSymLinks
-        AllowOverride All
-        DirectoryIndex index.php index.html
-
-        # Apache 2.4 access controls.
-        <IfModule mod_authz_core.c>
-            Require all granted
-        </IfModule>
-#</Location>
-    </Directory>
-
-    <Directory /usr/share/xdmod/html/rest>
-#<Location /xdmod/rest>
-        RewriteEngine On
-        RewriteRule (.*) index.php [L]
-#</Location>
-    </Directory>
-
-    ## SimpleSAML federated authentication.
-    #SetEnv SIMPLESAMLPHP_CONFIG_DIR /etc/xdmod/simplesamlphp/config
-    #Alias /simplesaml /usr/share/xdmod/vendor/simplesamlphp/simplesamlphp/www
-    #<Directory /usr/share/xdmod/vendor/simplesamlphp/simplesamlphp/www>
-    #    Options FollowSymLinks
-    #    AllowOverride All
-    #    # Apache 2.4 access controls.
-    #    <IfModule mod_authz_core.c>
-    #        Require all granted
-    #    </IfModule>
-    #</Directory>
-
-    ErrorLog /var/log/xdmod/apache-error.log
-    CustomLog /var/log/xdmod/apache-access.log combined
+    ServerName {{ ServerName }}
+    Redirect permanent / https://{{ ServerName }}/
 </VirtualHost>
+
+<IfModule mod_ssl.c>
+    <VirtualHost *:443>
+        ServerName {{ ServerName }}
+        DocumentRoot /usr/share/xdmod/html
+
+        SSLEngine on
+        SSLCertificateFile {{ SSLCertificateFile }}
+        SSLCertificateKeyFile {{ SSLCertificateKeyFile }}
+
+        <Directory /usr/share/xdmod/html>
+            Options FollowSymLinks
+            AllowOverride All
+            DirectoryIndex index.php index.html
+
+            <IfModule mod_authz_core.c>
+                Require all granted
+            </IfModule>
+        </Directory>
+
+        <Directory /usr/share/xdmod/html/rest>
+            RewriteEngine On
+            RewriteRule (.*) index.php [L]
+        </Directory>
+
+        SetEnv SIMPLESAMLPHP_CONFIG_DIR /etc/xdmod/simplesamlphp/config
+        Alias /simplesaml /usr/share/xdmod/vendor/simplesamlphp/simplesamlphp/www
+        <Directory /usr/share/xdmod/vendor/simplesamlphp/simplesamlphp/www>
+            Options FollowSymLinks
+            AllowOverride All
+            <IfModule mod_authz_core.c>
+                Require all granted
+            </IfModule>
+        </Directory>
+        {% endif %}
+
+        ErrorLog "|/usr/sbin/rotatelogs -n 5 /var/log/xdmod/apache-error.log 1M"
+        CustomLog "|/usr/sbin/rotatelogs -n 5 /var/log/xdmod/apache-access.log 1M" combined
+    </VirtualHost>
+</IfModule>
+


### PR DESCRIPTION
This commit includes changes to the xdmod.conf file within the openxdmod role, which adds a virtual host (VHost) for HTTPS. The necessary variables have been updated in group_vars/all to support this change.

Specifically, the changes to the xdmod.conf file include the addition of a new server block with the appropriate SSL configurations for HTTPS. In group_vars/all, variables such as SSL certificates and keys have been updated to reflect this new configuration.