### PR TITLE
Addition: Restart httpd service

### DIFF
--- a/roles/uab_skin/tasks/main.yaml
+++ b/roles/uab_skin/tasks/main.yaml
@@ -91,5 +91,11 @@
     insertafter: '(SSLCertificateKeyFile ).*'
     line: '    SSLCertificateChainFile /etc/ssl/certs/xdmod.rc.uab.edu-2048-incommon-interm.crt'
     state: present
+
+- name: Restart httpd service
+  become: true
+  systemd:
+    name: httpd.service
+    state: restarted
   
 


### PR DESCRIPTION
Description: This commit introduces a task with elevated privileges (become: true) to restart the httpd service using systemd. The reason for this restart is to address an issue where the login button was encountering errors.