### PR TITLE
Update user_manual link in configuration

### DIFF
--- a/roles/openxdmod/templates/portal_settings.ini.j2
+++ b/roles/openxdmod/templates/portal_settings.ini.j2
@@ -1,7 +1,7 @@
 [general]
 title = "Open XDMoD"
 site_address = "{{ xdmod_address }}"
-user_manual = "{{ xdmod_address }}user_manual/index.php"
+user_manual = "{{ xdmod_address }}user_manual/"
 contact_page_recipient = "{{ xdmod_contact_email }}"
 tech_support_recipient = "{{ xdmod_admin_email }}"
 

--- a/roles/openxdmod/templates/portal_settings.ini.j2
+++ b/roles/openxdmod/templates/portal_settings.ini.j2
@@ -1,7 +1,7 @@
 [general]
 title = "Open XDMoD"
 site_address = "{{ xdmod_address }}"
-user_manual = "{{ xdmod_address }} user_manual/"
+user_manual = "{{ xdmod_address }}user_manual/index.php"
 contact_page_recipient = "{{ xdmod_contact_email }}"
 tech_support_recipient = "{{ xdmod_admin_email }}"
 


### PR DESCRIPTION
In this commit, the `user_manual` configuration parameter has been updated to point to the new user manual location. Previously, it was set as `{{ xdmod_address }} user_manual`, and now it points to `{{ xdmod_address }}user_manual/index.php`. This change ensures that the user manual link correctly directs users to the updated location.