### PR TITLE
Update username length constant in constants.php

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -38,6 +38,7 @@
   xdmod_ingestor_start_date: "date +'\\%F'"
   xdmod_ingestor_end_date: "date -d 'next day' +'\\%F'"
 
+  xdmod_min_username_length: 2
   sacct_log_file_path: ""
 
 # SUPReMM

--- a/roles/uab_skin/tasks/main.yaml
+++ b/roles/uab_skin/tasks/main.yaml
@@ -92,6 +92,14 @@
     line: '    SSLCertificateChainFile /etc/ssl/certs/xdmod.rc.uab.edu-2048-incommon-interm.crt'
     state: present
 
+- name: Replace constant in constants.php
+  become: yes
+  replace:
+    path: /usr/share/xdmod/configuration/constants.php
+    regexp: "(define\\('RESTRICTION_USERNAME[^{]*{)\\d(.*)$"
+    replace: "\\1 {{xdmod_min_username_length}}\\2"
+    backup: true
+
 - name: Restart httpd service
   become: true
   systemd:

--- a/roles/uab_skin/tasks/main.yaml
+++ b/roles/uab_skin/tasks/main.yaml
@@ -97,7 +97,7 @@
   replace:
     path: /usr/share/xdmod/configuration/constants.php
     regexp: "(define\\('RESTRICTION_USERNAME[^{]*{)\\d(.*)$"
-    replace: "\\1 {{xdmod_min_username_length}}\\2"
+    replace: "\\g<1>{{xdmod_min_username_length}}\\g<2>"
     backup: true
 
 - name: Restart httpd service


### PR DESCRIPTION
This PR updates the `constants.php` file to replace the `RESTRICTION_USERNAME` constant with `{{xdmod_min_username_length}}` as part of the system's configuration.