### PR TITLE
Feat list schemas for db creation

### DIFF
--- a/roles/openxdmod/tasks/main.yml
+++ b/roles/openxdmod/tasks/main.yml
@@ -91,15 +91,24 @@
      dest: /usr/share/xdmod/tools/dev/extract_chart_configs.php
      mode: '0744'
 
+ - name: Find the DB schema files so that they can be initialized in the next step
+   ansible.builtin.find:
+     paths: "{{ item }}"
+     file_type: file
+     patterns: '\w+.sql$'
+     use_regex: yes
+   loop:
+     - /usr/share/xdmod/db/schema
+     - /usr/share/xdmod/db/data
+   register: output
+
 #Need to initialize databases still
  - name: initialize xdmod databases
    mysql_db:
      name: "{{ item | basename | regex_replace('.sql','') }}"
      state: import
      target: "{{ item }}"
-   with_fileglob:
-     - /usr/share/xdmod/db/schema/*
-     - /usr/share/xdmod/db/data/*
+   loop: "{{ output | json_query('results[*].files[*].path') | flatten(levels=1) }}"
 
  - name: create db user
    mysql_user:


### PR DESCRIPTION
Issue: 
Ansible `with_fileglob` module expects to find the file patterns in local filesystem.

According to https://docs.ansible.com/ansible/2.9_ja/plugins/lookup/fileglob.html
with_file_glob matching is against local system files on the Ansible controller. To iterate a list of files on a remote node, use the [find](https://docs.ansible.com/ansible/2.9_ja/modules/find_module.html#find-module) module.

Previously we were using ansible-local provisioner from packer so we did not see this issue as the module was looking at the local filesystem but with the current approach where ansible tasks are executed remotely from a host controller, the ansible module `with_fileglob` we expected it to see the files on remote host but it was still looking at the host controller.

Solution:
This PR resolves this issue by using the ansible.builtin.find module that will return a list of files that match a certain pattern.
This list is used in next step to init the DBs