### PR TITLE
Use URL to download and extract the simplesaml tar file

### DIFF
--- a/roles/simplesaml/tasks/main.yml
+++ b/roles/simplesaml/tasks/main.yml
@@ -8,23 +8,9 @@
       - mod_php
     state: latest
 
-- name: Create SimpleSAMLphp directory in /tmp and delete its contents if it exists
-  file:
-    path: /tmp/simplesamlphp/
-    state: directory
-    mode: '0755'
-    recurse: yes
-    # This option will remove all files and directories inside /tmp/simplesamlphp/ before creating it.
-
-- name: Download SimpleSAMLphp to /tmp dir
-  get_url:
-    url: "{{ simplesaml_url }}"
-    dest: /tmp/simplesamlphp/
-    mode: '0755'
-
 - name: Extract SimpleSAMLphp
   unarchive:
-    src: "{{ lookup('fileglob', '/tmp/simplesamlphp/*.tar.gz') }}"
+    src: "{{ simplesaml_url }}"
     dest: /var/www/
     remote_src: true
     extra_opts: [--strip-components=1]


### PR DESCRIPTION
This PR fixes the failure in ansible playbook runs seen when making a switch to ansible-remote. 
Using a URL in ansible.builtin.unarchive module takes care of downloading and extracting the tar.gz file. We don't need to explicitly do those steps in our ansible tasks as it is handled by ansible itself. 
Finally, the fileglob filter in lookup plugin only looks at the local filesystem. So this task was failing. It is fixed in this PR.
 