### PR TITLE
Change reference to extra-vars passed via packer ansible provisioner

### DIFF
--- a/roles/simplesaml/tasks/main.yml
+++ b/roles/simplesaml/tasks/main.yml
@@ -55,32 +55,32 @@
 
 - name: create a shib directory in /tmp
   file:
-    path: "/tmp/{{ lookup('env', 's3_shibboleth_bucket_name') }}"
+    path: "/tmp/{{ s3_shibboleth_bucket_name }}"
     state: directory
 
 - name: Adding a debug step to print out the LTS env variables
   ansible.builtin.debug:
     msg:
-    - "s3_endpoint: {{ lookup('env', 's3_endpoint') }}"
-    - "s3_shibboleth_bucket_name: {{ lookup('env', 's3_shibboleth_bucket_name') }}"
-    - "s3_shibboleth_object_name: {{ lookup('env', 's3_shibboleth_object_name') }}"
+    - "s3_endpoint: {{ s3_endpoint }}"
+    - "s3_shibboleth_bucket_name: {{ s3_shibboleth_bucket_name }}"
+    - "s3_shibboleth_object_name: {{ s3_shibboleth_object_name }}"
 
 - name: Download shibboleth tar from S3
   aws_s3:
     mode: get
-    s3_url: "{{ lookup('env', 's3_endpoint') }}"
-    bucket: "{{ lookup('env', 's3_shibboleth_bucket_name') }}"
-    object: "{{ lookup('env', 's3_shibboleth_object_name') }}"
-    dest: "/tmp/{{ lookup('env', 's3_shibboleth_object_name') }}"
-    aws_access_key: "{{ lookup('env', 'lts_access_key') }}"
-    aws_secret_key: "{{ lookup('env', 'lts_secret_key') }}"
+    s3_url: "{{ s3_endpoint }}"
+    bucket: "{{ s3_shibboleth_bucket_name }}"
+    object: "{{ s3_shibboleth_object_name }}"
+    dest: "/tmp/{{ s3_shibboleth_object_name }}"
+    aws_access_key: "{{ lts_access_key }}"
+    aws_secret_key: "{{ lts_secret_key }}"
   vars:
     ansible_python_interpreter: /usr/bin/python3
 
 - name: Extract tar.gz into /tmp/
   unarchive:
-    src: "/tmp/{{ lookup('env', 's3_shibboleth_object_name') }}"
-    dest: "/tmp/{{ lookup('env', 's3_shibboleth_bucket_name') }}"
+    src: "/tmp/{{ s3_shibboleth_object_name }}"
+    dest: "/tmp/{{ s3_shibboleth_bucket_name }}"
     remote_src: yes
 
 - name: Copy all the cert and metadata files to appropriate destinations
@@ -90,10 +90,10 @@
     dest: "{{ item.dest }}"
     mode: '0644'
   loop:
-    - { src: "/tmp/{{ lookup('env', 's3_shibboleth_bucket_name') }}/key.pem", dest: "/etc/xdmod/simplesamlphp/cert/key.pem" }
-    - { src: "/tmp/{{ lookup('env', 's3_shibboleth_bucket_name') }}/cert.pem", dest: "/etc/xdmod/simplesamlphp/cert/cert.pem" }
-    - { src: "/tmp/{{ lookup('env', 's3_shibboleth_bucket_name') }}/authsources.php", dest: "/etc/xdmod/simplesamlphp/config/authsources.php" }
-    - { src: "/tmp/{{ lookup('env', 's3_shibboleth_bucket_name') }}/saml20-idp-remote.php", dest: "/etc/xdmod/simplesamlphp/metadata/saml20-idp-remote.php" }
+    - { src: "/tmp/{{ s3_shibboleth_bucket_name }}/key.pem", dest: "/etc/xdmod/simplesamlphp/cert/key.pem" }
+    - { src: "/tmp/{{ s3_shibboleth_bucket_name }}/cert.pem", dest: "/etc/xdmod/simplesamlphp/cert/cert.pem" }
+    - { src: "/tmp/{{ s3_shibboleth_bucket_name }}/authsources.php", dest: "/etc/xdmod/simplesamlphp/config/authsources.php" }
+    - { src: "/tmp/{{ s3_shibboleth_bucket_name }}/saml20-idp-remote.php", dest: "/etc/xdmod/simplesamlphp/metadata/saml20-idp-remote.php" }
 
 - name: Copy config file from templates to destination
   template:

--- a/roles/simplesaml/tasks/main.yml
+++ b/roles/simplesaml/tasks/main.yml
@@ -89,6 +89,7 @@
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     mode: '0644'
+    remote_src: yes
   loop:
     - { src: "/tmp/{{ s3_shibboleth_bucket_name }}/key.pem", dest: "/etc/xdmod/simplesamlphp/cert/key.pem" }
     - { src: "/tmp/{{ s3_shibboleth_bucket_name }}/cert.pem", dest: "/etc/xdmod/simplesamlphp/cert/cert.pem" }


### PR DESCRIPTION
Previously, vars are passed as env vars when using shell provisioner to run ansible playbooks so lookup was used but when running playbooks via ansible provisioner we pass them via extra-vars and they can't be referenced by lookup so refer them as normal ansible var