### PR TITLE
Cast the conditional used in the playbook to bool

### DIFF
--- a/clustermon.yml
+++ b/clustermon.yml
@@ -3,11 +3,11 @@
  - hosts: headnode
    roles:
 
-     - {role: ganglia, tags: ganglia, when: enable_ganglia} #temporarily commented while working on openxdmod
-     - {role: job_archiver, tags: job_archiver, when: enable_job_archiver}
-     - {role: openxdmod, tags: openxdmod, when: enable_openxdmod}
-     - {role: selinix_permissive, tags: selinix_permissive, when: enable_selinix_permissive}
-     - {role: openssl_cert_gen, tags: openssl_cert_gen, when: openssl_cert_gen}
-     - {role: supremm, tags: supremm, when: enable_supremm}
-     - {role: simplesaml, tags: simplesaml, when: enable_simplesaml}
-     - {role: uab_skin, tags: uab_skin, when: enable_UAB_UI}
+     - {role: ganglia, tags: ganglia, when: enable_ganglia | bool} #temporarily commented while working on openxdmod
+     - {role: job_archiver, tags: job_archiver, when: enable_job_archiver | bool}
+     - {role: openxdmod, tags: openxdmod, when: enable_openxdmod | bool}
+     - {role: selinix_permissive, tags: selinix_permissive, when: enable_selinix_permissive | bool}
+     - {role: openssl_cert_gen, tags: openssl_cert_gen, when: openssl_cert_gen | bool}
+     - {role: supremm, tags: supremm, when: enable_supremm | bool}
+     - {role: simplesaml, tags: simplesaml, when: enable_simplesaml | bool}
+     - {role: uab_skin, tags: uab_skin, when: enable_UAB_UI | bool}


### PR DESCRIPTION
This allows for using conditional vars as boolean values when passing them through extra-vars. By default, they are considered strings when you pass them through extra-vars.